### PR TITLE
pkcs11-hse: -fPIC option is missing from CFLAGS

### DIFF
--- a/recipes-bsp/hse/pkcs11-hse.bb
+++ b/recipes-bsp/hse/pkcs11-hse.bb
@@ -15,7 +15,7 @@ RDEPENDS:${PN} += "libp11 openssl hse-firmware"
 
 S = "${WORKDIR}/git"
 
-CFLAGS:append = " ${HOST_CC_ARCH}${TOOLCHAIN_OPTIONS}"
+CFLAGS:append = " ${HOST_CC_ARCH}${TOOLCHAIN_OPTIONS} -fPIC"
 
 EXTRA_OEMAKE += " \
                 CROSS_COMPILE=${TARGET_PREFIX} \


### PR DESCRIPTION
It is set in the Makefile of pkcs11-hse; but the recipes overrides that. Missing this flag results in "recompile with -fPIC" errors when compiling the recipe.