### PR TITLE
busybox_%.bbappend: fix systemd boot

### DIFF
--- a/dynamic-layers/core/recipes-core/busybox/busybox_%.bbappend
+++ b/dynamic-layers/core/recipes-core/busybox/busybox_%.bbappend
@@ -6,7 +6,7 @@ ALTERNATIVE_PRIORITY[init] = "40"
 
 SRC_URI += " \
     file://externaldhcp.cfg \
-    file://init.cfg \
+    ${@["", " file://init.cfg"][(d.getVar('VIRTUAL-RUNTIME_init_manager') == 'busybox')]} \
     file://enabledhcpcopts.patch \
 "
 


### PR DESCRIPTION
# otherwise no systemd init.cfg is used always, mean /sbin/init is pointing at busybox, by this modification this is only using init.cfg when busybox is enabled, as it is in done in poky layer.