### PR TITLE
Fix ld.so segmentation fault on native sdk

### DIFF
--- a/recipes-core/glibc2.31/glibc/0001-x86-Fix-THREAD_SELF-definition-to-avoid-ld.so-crash-.patch
+++ b/recipes-core/glibc2.31/glibc/0001-x86-Fix-THREAD_SELF-definition-to-avoid-ld.so-crash-.patch
@@ -1,0 +1,63 @@
+From bd29f35bfe0737b547528597b87a25aaf7f71c9b Mon Sep 17 00:00:00 2001
+From: Jakub Jelinek <jakub@redhat.com>
+Date: Thu, 3 Dec 2020 13:33:44 +0100
+Subject: [PATCH] x86: Fix THREAD_SELF definition to avoid ld.so crash (bug
+ 27004)
+
+The previous definition of THREAD_SELF did not tell the compiler
+that %fs (or %gs) usage is invalid for the !DL_LOOKUP_GSCOPE_LOCK
+case in _dl_lookup_symbol_x.  As a result, ld.so could try to use the
+TCB before it was initialized.
+
+As the comment in tls.h explains, asm volatile is undesirable here.
+Using the __seg_fs (or __seg_gs) namespace does not interfere with
+optimization, and expresses that THREAD_SELF is potentially trapping.
+---
+ sysdeps/i386/nptl/tls.h   | 7 ++++++-
+ sysdeps/x86_64/nptl/tls.h | 7 ++++++-
+ 2 files changed, 12 insertions(+), 2 deletions(-)
+
+diff --git a/sysdeps/i386/nptl/tls.h b/sysdeps/i386/nptl/tls.h
+index d1bf90a503..55de6c18a2 100644
+--- a/sysdeps/i386/nptl/tls.h
++++ b/sysdeps/i386/nptl/tls.h
+@@ -241,11 +241,16 @@ tls_fill_user_desc (union user_desc_init *desc,
+    assignments like
+ 	pthread_descr self = thread_self();
+    do not get optimized away.  */
+-# define THREAD_SELF \
++# if __GNUC_PREREQ (6, 0)
++#  define THREAD_SELF \
++  (*(struct pthread *__seg_gs *) offsetof (struct pthread, header.self))
++# else
++#  define THREAD_SELF \
+   ({ struct pthread *__self;						      \
+      asm ("movl %%gs:%c1,%0" : "=r" (__self)				      \
+ 	  : "i" (offsetof (struct pthread, header.self)));		      \
+      __self;})
++# endif
+ 
+ /* Magic for libthread_db to know how to do THREAD_SELF.  */
+ # define DB_THREAD_SELF \
+diff --git a/sysdeps/x86_64/nptl/tls.h b/sysdeps/x86_64/nptl/tls.h
+index e7c1416eec..5d0788c8fe 100644
+--- a/sysdeps/x86_64/nptl/tls.h
++++ b/sysdeps/x86_64/nptl/tls.h
+@@ -186,11 +186,16 @@ _Static_assert (offsetof (tcbhead_t, __glibc_unused2) == 0x80,
+    assignments like
+ 	pthread_descr self = thread_self();
+    do not get optimized away.  */
+-# define THREAD_SELF \
++# if __GNUC_PREREQ (6, 0)
++#  define THREAD_SELF \
++  (*(struct pthread *__seg_fs *) offsetof (struct pthread, header.self))
++# else
++#  define THREAD_SELF \
+   ({ struct pthread *__self;						      \
+      asm ("mov %%fs:%c1,%0" : "=r" (__self)				      \
+ 	  : "i" (offsetof (struct pthread, header.self)));	 	      \
+      __self;})
++# endif
+ 
+ /* Magic for libthread_db to know how to do THREAD_SELF.  */
+ # define DB_THREAD_SELF_INCLUDE  <sys/reg.h> /* For the FS constant.  */

--- a/recipes-core/glibc2.31/glibc_2.31.bbappend
+++ b/recipes-core/glibc2.31/glibc_2.31.bbappend
@@ -7,4 +7,5 @@ SRC_URI += " \
     file://0005-glibc2.31-gcc-11-declaration-hack.patch \
     file://0006-glibc2.31-Fixed-what-appears-to-be-a-genuine-declara.patch \
     file://0007-glibc2.31-gcc-11-array-bounds-hack.patch \
+    file://0001-x86-Fix-THREAD_SELF-definition-to-avoid-ld.so-crash-.patch \
 "


### PR DESCRIPTION
After installing a native sdk generated with
`bitbake fsl-image-base -c populate_sdk`, any binary from the sdk was seg faulting.

The reason is that GCC11 triggered a glibc bug on x86-64 that was fixed only on glibc 2.33. So in order to use 2.31 we need to backport the patch.

Reference: https://sourceware.org/bugzilla/show_bug.cgi?id=27033

## Testing

An easy way to test this is to build the native glibc:

```
bitbake nativesdk-glibc
```

Then manually run the built ld-linux with any other binary. Without the patch, it seg faults:

```
./tmp/work/x86_64-nativesdk-fslbsp-linux/nativesdk-glibc/2.31+gitAUTOINC+1094741224-r0/sysroot-destdir/usr/local/oe-sdk-hardcoded-buildpath/sysroots/x86_64-fslbsp-linux/lib/ld-linux-x86-64.so.2 /usr/bin/true
Segmentation fault (core dumped)
```

With the patch, the loader runs normally (and will give some expected error about libs that were not found):

```
./tmp/work/x86_64-nativesdk-fslbsp-linux/nativesdk-glibc/2.31+gitAUTOINC+1094741224-r0/sysroot-destdir/usr/local/oe-sdk-hardcoded-buildpath/sysroots/x86_64-fslbsp-linux/lib/ld-linux-x86-64.so.2 /usr/bin/true
/usr/bin/true: error while loading shared libraries: libc.so.6: cannot open shared object file: No such file or directory
```