### PR TITLE
Update pkcs11-hse.bb

### DIFF
--- a/recipes-bsp/hse/pkcs11-hse.bb
+++ b/recipes-bsp/hse/pkcs11-hse.bb
@@ -11,7 +11,7 @@ SRC_URI = "${URL};branch=${BRANCH}"
 SRCREV ?= "b90de006c39bb1dcf060b7178d0a832dfa75a24d"
 
 DEPENDS += "libp11 openssl hse-firmware"
-RDEPENDS:${PN} += "libp11 openssl hse-firmware"
+RDEPENDS:${PN} += "libp11 openssl-bin hse-firmware"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Update pkcs11-hse to runtime depend on openssl-bin. pkcs11-hse relies on bin/openssl binary, and it is provided by openssl-bin inside yocto recipe.

packages-split/openssl-bin/usr
packages-split/openssl-bin/usr/bin
packages-split/openssl-bin/usr/bin/openssl